### PR TITLE
Add explicit request timeout to WorkIQ MCP server configs

### DIFF
--- a/plugins/workiq-preview/.mcp.json
+++ b/plugins/workiq-preview/.mcp.json
@@ -5,6 +5,7 @@
       "url": "https://workiq.svc.cloud.microsoft/mcp",
       "oauthClientId": "ba081686-5d24-4bc6-a0d6-d034ecffed87",
       "oauthPublicClient": true,
+      "timeout": 300000,
       "auth": {
         "redirectPort": 12798
       }

--- a/plugins/workiq/.mcp.json
+++ b/plugins/workiq/.mcp.json
@@ -5,6 +5,7 @@
       "url": "https://workiq.svc.cloud.microsoft/mcp",
       "oauthClientId": "ba081686-5d24-4bc6-a0d6-d034ecffed87",
       "oauthPublicClient": true,
+      "timeout": 300000,
       "auth": {
         "redirectPort": 12798
       }


### PR DESCRIPTION
Adds a `timeout` to the `workiq` and `workiq-preview` MCP server definitions.

```diff
       "oauthPublicClient": true,
+      "timeout": 300000,
       "auth": {
```

**Why:** neither config declared a request timeout, so a stalled tool call had no client-side bound.

**Why 300000 ms:** it matches the service's server-side response ceiling, so it will not truncate a call that would otherwise have completed.

**Note:** not all MCP clients currently enforce a per-server timeout, so the practical effect varies by client. The value is correct regardless and takes effect wherever the field is honored.