### PR TITLE
Add Business Applications guidance to workiq-preview skill

### DIFF
--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -62,13 +62,6 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 
 **DO NOT say "I don't have access to emails/meetings/messages"** - use WorkIQ instead!
 
-> **Business Applications exact-scope check comes first.** Before inspecting
-> schemas or records, read `references/business-applications.md` and use
-> `/businessapps/me` to resolve an explicitly named environment, app, skill,
-> measure, tier, status, or governed term. If that exact scope or term is not
-> available, follow the reference's stop/clarify behavior; do not infer a
-> nearby field or broaden discovery into other environments.
-
 > **🛑 Tasks are M365 data — never a local fallback.** "Add a task", "remind me to…",
 > "follow up with…", "mark … done" all route to WorkIQ entity tools
 > (`/planner/...` for Planner tasks). **Do not** create a

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -52,6 +52,7 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 | Listing files in a OneDrive/SharePoint folder | "List files in my OneDrive 'Specs' folder" | `fetch` |
 | Listing tasks/plans/buckets in Planner | "List my Planner tasks due this week" | `fetch` — see `references/tasks-work-iq.md` avoid `ask` |
 | Listing / creating / completing Planner tasks | "Add a task to follow up with finance", "Mark my task done", "List my Planner tasks" | entity tools on `/planner/...` — see `references/tasks-work-iq.md` |
+| Structured records or workflows in CRM, ERP, or Power Apps | "Qualify a lead", "Update the open service case" | start with `do_action` `/applications/me` and `{"query":"qualify a lead"}`, then follow the returned app and operation paths — read `references/business-applications.md` first |
 | Get a personal contact by name | "Get the contact card for Morgan Avery" | `fetch` (`/me/contacts?$filter=...`) — subject to server policy |
 | List or manage Outlook categories | "What Outlook categories do I have?" | `fetch` (`/me/outlook/masterCategories`); writes subject to server policy |
 | Org chart / direct reports / manager lookup | "Who are Rob's direct reports?" | `fetch` (`/users/{id}/directReports`) |
@@ -94,6 +95,7 @@ When the user asks to delete, update, send, forward, copy, move, or react to som
 | "Delete" any entity | `fetch` to find it | `delete_entity` on the entity URL |
 | "Update/rename/change" any entity | `fetch` to find it | `update_entity` on the entity URL |
 | "Create draft and send" | `create_entity` to draft | `do_action` `/me/messages/{id}/send` |
+| "Qualify a lead" | `do_action` `/applications/me` with `{"query":"qualify a lead"}` to resolve the app, environment, and operation path | `get_schema`, then `do_action` on the exact returned app-scoped operation |
 
 Common failure: fetching the entity and stopping, asking the user "did you want me to do anything else?", or saying "I found it." The user asked you to do something — finish it.
 
@@ -227,6 +229,7 @@ Entity tools provide **fast, direct access to specific M365 data** via Work IQ A
 | Calendar | `/me/events`, `/me/calendarView` | list/get/create/update/delete; accept/decline via `/me/events/{id}/{action}` |
 | Planner | `/me/planner/plans`, `/planner/tasks` | list/create/update/complete/delete — see `references/tasks-work-iq.md` |
 | Teams | `/me/chats`, `/chats/{chatId}/messages`, `/me/joinedTeams`, `/teams/{teamId}/channels/{channelId}/messages`, `/me/presence` | chats vs channels are different surfaces — see `references/teams-work-iq.md` |
+| Business Applications | `/applications/me` | semantic discovery of business apps, records, and workflows via `do_action` with a `query`; follow the returned paths — see `references/business-applications.md` |
 | People | `/me`, `/users/{id}`, `/users/{id}/directReports`, `/me/manager`, `/me/contacts` | profile, org, contacts — see directory-vs-contacts warning below |
 | Outlook categories | `/me/outlook/masterCategories` | list/get/create/update/delete — writes commonly policy-denied |
 | Files | `/me/drive`, `/drives/{id}`, `/sites/{id}` | list/get JSON metadata with `fetch`; download binary content with `fetch_blob` - see `references/fetch-blob-work-iq.md`; uploads are not released yet |
@@ -399,7 +402,20 @@ Read the relevant reference file for full parameter details and examples:
 - `references/mail-work-iq.md` — if you need to find, draft, send, reply, forward, move, or delete mail (covers `$search` vs `$filter` and the mail-delta endpoint)
 - `references/tasks-work-iq.md` — if you need to list, create, update, complete, or delete Planner tasks
 - `references/teams-work-iq.md` — if you need to send, reply, react, or read Teams chat/channel messages, or get/set presence
+- `references/business-applications.md` — if you need to discover or use business-application environments, data, apps, skills, APIs, operations, or delegated work
 - `references/update-entity-work-iq.md` — if you need to update fields on an existing entity
 - `references/delete-entity-work-iq.md` — if you need to delete an entity
 - `references/do-action-work-iq.md` — if you need to send mail, accept/decline meetings, copy/move messages
 - `references/troubleshooting.md` — if a tool call fails unexpectedly, returns an error, or behaves differently than documented
+
+## Business Applications (`/applications`)
+
+WorkIQ exposes business-application environments, data, apps, skills, APIs, and operations under `/applications/`,
+which is distinct from Microsoft Graph application registrations. Business Applications are systems of record for
+structured operational data and workflows, such as customer and sales records in CRM, finance or supply-chain
+records in ERP, and line-of-business data in Power Apps. Route intent tied to records or workflows in a business
+system to `/applications`; use Graph for Microsoft 365 collaboration and directory content such as mail, Teams,
+calendars, files, and people. Read `references/business-applications.md` before handling a Business Applications
+request. Start intent-driven discovery with `do_action` on `/applications/me` and a concise `query` describing the
+needed record, workflow, or app; use the returned paths, environment, and application IDs. Example:
+`actionUrl: "/applications/me"` with `jsonBody: {"query":"qualify a lead"}`.

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -62,6 +62,13 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 
 **DO NOT say "I don't have access to emails/meetings/messages"** - use WorkIQ instead!
 
+> **Business Applications exact-scope check comes first.** Before inspecting
+> schemas or records, read `references/business-applications.md` and use
+> `/businessapps/me` to resolve an explicitly named environment, app, skill,
+> measure, tier, status, or governed term. If that exact scope or term is not
+> available, follow the reference's stop/clarify behavior; do not infer a
+> nearby field or broaden discovery into other environments.
+
 > **🛑 Tasks are M365 data — never a local fallback.** "Add a task", "remind me to…",
 > "follow up with…", "mark … done" all route to WorkIQ entity tools
 > (`/planner/...` for Planner tasks). **Do not** create a

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -114,6 +114,12 @@ Common failure: fetching the entity and stopping, asking the user "did you want 
 >   tool response confirms it (2xx/created/updated). If you could not find the target or the
 >   write failed, say so — do not substitute a different action (e.g., sending a new email
 >   instead of replying) and report the original request as completed.
+> - **Authorization and privilege failures are terminal for that requested
+>   mutation.** When a write returns an explicit missing privilege, access
+>   denial, or policy denial, stop the mutation workflow immediately. Do not
+>   search for another endpoint, delegated agent, app operation, record/view
+>   update, or other workaround that tries to achieve the same change through
+>   a different resource.
 
 ### Grounding rules
 

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -52,7 +52,7 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 | Listing files in a OneDrive/SharePoint folder | "List files in my OneDrive 'Specs' folder" | `fetch` |
 | Listing tasks/plans/buckets in Planner | "List my Planner tasks due this week" | `fetch` — see `references/tasks-work-iq.md` avoid `ask` |
 | Listing / creating / completing Planner tasks | "Add a task to follow up with finance", "Mark my task done", "List my Planner tasks" | entity tools on `/planner/...` — see `references/tasks-work-iq.md` |
-| Structured records or workflows in CRM, ERP, or Power Apps | "Qualify a lead", "Update the open service case" | start with `do_action` `/applications/me` and `{"query":"qualify a lead"}`, then follow the returned app and operation paths — read `references/business-applications.md` first |
+| Structured records or workflows in CRM, ERP, or Power Apps | "Qualify a lead", "Update the open service case" | start with `do_action` `/businessapps/me` and `{"query":"qualify a lead"}`, then follow the returned app and operation paths — read `references/business-applications.md` first |
 | Get a personal contact by name | "Get the contact card for Morgan Avery" | `fetch` (`/me/contacts?$filter=...`) — subject to server policy |
 | List or manage Outlook categories | "What Outlook categories do I have?" | `fetch` (`/me/outlook/masterCategories`); writes subject to server policy |
 | Org chart / direct reports / manager lookup | "Who are Rob's direct reports?" | `fetch` (`/users/{id}/directReports`) |
@@ -95,7 +95,7 @@ When the user asks to delete, update, send, forward, copy, move, or react to som
 | "Delete" any entity | `fetch` to find it | `delete_entity` on the entity URL |
 | "Update/rename/change" any entity | `fetch` to find it | `update_entity` on the entity URL |
 | "Create draft and send" | `create_entity` to draft | `do_action` `/me/messages/{id}/send` |
-| "Qualify a lead" | `do_action` `/applications/me` with `{"query":"qualify a lead"}` to resolve the app, environment, and operation path | `get_schema`, then `do_action` on the exact returned app-scoped operation |
+| "Qualify a lead" | `do_action` `/businessapps/me` with `{"query":"qualify a lead"}` to resolve the app, environment, and operation path | `get_schema`, then `do_action` on the exact returned app-scoped operation |
 
 Common failure: fetching the entity and stopping, asking the user "did you want me to do anything else?", or saying "I found it." The user asked you to do something — finish it.
 
@@ -229,7 +229,7 @@ Entity tools provide **fast, direct access to specific M365 data** via Work IQ A
 | Calendar | `/me/events`, `/me/calendarView` | list/get/create/update/delete; accept/decline via `/me/events/{id}/{action}` |
 | Planner | `/me/planner/plans`, `/planner/tasks` | list/create/update/complete/delete — see `references/tasks-work-iq.md` |
 | Teams | `/me/chats`, `/chats/{chatId}/messages`, `/me/joinedTeams`, `/teams/{teamId}/channels/{channelId}/messages`, `/me/presence` | chats vs channels are different surfaces — see `references/teams-work-iq.md` |
-| Business Applications | `/applications/me` | semantic discovery of business apps, records, and workflows via `do_action` with a `query`; follow the returned paths — see `references/business-applications.md` |
+| Business Applications | `/businessapps/me` | semantic discovery of business apps, records, and workflows via `do_action` with a `query`; follow the returned paths — see `references/business-applications.md` |
 | People | `/me`, `/users/{id}`, `/users/{id}/directReports`, `/me/manager`, `/me/contacts` | profile, org, contacts — see directory-vs-contacts warning below |
 | Outlook categories | `/me/outlook/masterCategories` | list/get/create/update/delete — writes commonly policy-denied |
 | Files | `/me/drive`, `/drives/{id}`, `/sites/{id}` | list/get JSON metadata with `fetch`; download binary content with `fetch_blob` - see `references/fetch-blob-work-iq.md`; uploads are not released yet |
@@ -408,14 +408,18 @@ Read the relevant reference file for full parameter details and examples:
 - `references/do-action-work-iq.md` — if you need to send mail, accept/decline meetings, copy/move messages
 - `references/troubleshooting.md` — if a tool call fails unexpectedly, returns an error, or behaves differently than documented
 
-## Business Applications (`/applications`)
+## Business Applications (`/businessapps`)
 
-WorkIQ exposes business-application environments, data, apps, skills, APIs, and operations under `/applications/`,
+WorkIQ exposes business-application environments, data, apps, skills, APIs, and operations under `/businessapps/`,
 which is distinct from Microsoft Graph application registrations. Business Applications are systems of record for
 structured operational data and workflows, such as customer and sales records in CRM, finance or supply-chain
 records in ERP, and line-of-business data in Power Apps. Route intent tied to records or workflows in a business
-system to `/applications`; use Graph for Microsoft 365 collaboration and directory content such as mail, Teams,
+system to `/businessapps`; use Graph for Microsoft 365 collaboration and directory content such as mail, Teams,
 calendars, files, and people. Read `references/business-applications.md` before handling a Business Applications
-request. Start intent-driven discovery with `do_action` on `/applications/me` and a concise `query` describing the
+request. Start intent-driven discovery with `do_action` on `/businessapps/me` and a concise `query` describing the
 needed record, workflow, or app; use the returned paths, environment, and application IDs. Example:
-`actionUrl: "/applications/me"` with `jsonBody: {"query":"qualify a lead"}`.
+`actionUrl: "/businessapps/me"` with `jsonBody: {"query":"qualify a lead"}`. Every Business Applications resource —
+environments, apps, tables, records, skills, and APIs — is discovered this way or with `search_paths`; take each
+identifier from the returned paths. Business skills are addressed as resources under
+`/businessapps/environments/{environmentId}/skills/{skillName}` and are readable with `fetch` and writable with
+`create_entity`, `update_entity`, and `delete_entity`.

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -1,52 +1,72 @@
 # Business Applications
 
-Use WorkIQ entity tools with paths under `/applications/` for business-application environments, data, apps,
+Use WorkIQ entity tools with paths under `/businessapps/` for business-application environments, data, apps,
 skills, APIs, and operations. This path space is distinct from Microsoft Graph application registrations. Do not
 substitute a separate endpoint, another MCP server, or an invented REST URL.
 
 ## Discovery and path grounding
 
-1. Start intent-driven discovery with `do_action` on `/applications/me` and
+1. Start intent-driven discovery with `do_action` on `/businessapps/me` and
    `{"query":"<business record, workflow, or app intent>","environmentId":"<optional>","limit":10}`. The `query`
    is required. Results include grounded paths plus environment and application IDs. For example, use
    `{"query":"qualify a lead"}` to discover the relevant sales application and operations.
-2. Use `fetch` on `/applications/environments/` when the user explicitly asks to list environments or identify the
-   default environment. Do not guess an environment ID.
-3. Use `search_paths` to discover Business Applications paths. Set `filter` to a plain leading-slash path such as
-   `/applications` for path-prefix matching, or to a regular expression over paths when a narrower pattern is
+2. Use `search_paths` to discover Business Applications paths. Set `filter` to a plain leading-slash path such as
+   `/businessapps` for path-prefix matching, or to a regular expression over paths when a narrower pattern is
    needed. The filter is **not a natural-language or semantic search**. Returned paths can be passed directly to
    `fetch`, `get_schema`, or a write tool.
+3. Discover **every** Business Applications resource this way — environments, apps, tables, records, skills, APIs,
+   and operations. Take each identifier from the returned paths. Do not guess an ID or name, and do not assume a
+   default environment.
 4. Use `get_schema` on the returned concrete path before an unfamiliar mutation or operation. Never fill in
-   `{environmentId}`, `{tableName}`, `{recordId}`, `{appName}`, `{apiName}`, or operation names from memory.
+   `{environmentId}`, `{tableName}`, `{recordId}`, `{appName}`, `{apiName}`, `{skillName}`, or operation names
+   from memory.
 
 ## Exact path and tool selection
 
 | Intent | WorkIQ tool and Business Applications path |
 |---|---|
-| List environments/default | `fetch` `/applications/environments/` |
-| List or describe tables | `fetch` or `get_schema` `/applications/environments/{environmentId}/tables[/<tableName>]` |
-| Read a record | `fetch` `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}` |
-| Query environment data | `call_function` `/applications/environments/{environmentId}/query` with `jsonBody: {"querytext":"SELECT ..."}` |
-| Create a table | `create_entity` on `/applications/environments/{environmentId}/tables` with `{tableName, columns, displayName?, description?}` |
-| Create a record | `create_entity` on `/applications/environments/{environmentId}/tables/{tableName}/records` with `{"item":{...}}` |
-| Update a record | `update_entity` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}` with changed fields |
+| List or describe tables | `fetch` or `get_schema` `/businessapps/environments/{environmentId}/tables[/<tableName>]` |
+| Read a record | `fetch` `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}` |
+| Query environment data | `call_function` `/businessapps/environments/{environmentId}/query` with `jsonBody: {"querytext":"SELECT ..."}` |
+| Create a table | `create_entity` on `/businessapps/environments/{environmentId}/tables` with `{tableName, columns, displayName?, description?}` |
+| Create a record | `create_entity` on `/businessapps/environments/{environmentId}/tables/{tableName}/records` with `{"item":{...}}` |
+| Update a record | `update_entity` on `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}` with changed fields |
 | Delete a record/table | `delete_entity` on the exact record or table path returned by discovery |
-| Upload a Business Applications record file | `do_action` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/upload` with the schema-defined file arguments |
-| Download a Business Applications record file | `call_function` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/download` with optional `destinationPath` |
-| List or inspect apps | `fetch` `/applications/environments/{environmentId}/apps[/<appName>]` |
+| Upload a Business Applications record file | `do_action` on `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/upload` with the schema-defined file arguments |
+| Download a Business Applications record file | `call_function` on `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/download` with optional `destinationPath` |
+| List or inspect apps | `fetch` `/businessapps/environments/{environmentId}/apps[/<appName>]` |
+| List or read a business skill | `fetch` `/businessapps/environments/{environmentId}/skills[/{skillName}]` |
+| Create a business skill | `create_entity` on `/businessapps/environments/{environmentId}/skills` with the schema-defined skill payload |
+| Update a business skill | `update_entity` on `/businessapps/environments/{environmentId}/skills/{skillName}` with changed fields |
+| Delete a business skill | `delete_entity` on `/businessapps/environments/{environmentId}/skills/{skillName}` |
 | Run an app-scoped operation | `do_action` on the exact `.../apps/{appName}/.../operations/{operationName}` path returned by `get_schema` |
-| Invoke a Custom API | `call_function` `/applications/environments/{environmentId}/apis/{apiName}` with the API inputs in `jsonBody` |
-| Delegate an open-ended goal to an environment | `do_action` `/applications/environments/{environmentId}/execute-work` with `{"instruction":"...","sessionId":"<optional>"}` |
-| Invoke an in-app MCP tool | `do_action` on the exact `/applications/environments/{environmentId}/mcp/{serverName}/tools/{toolName}` path |
+| Invoke a Custom API | `call_function` `/businessapps/environments/{environmentId}/apis/{apiName}` with the API inputs in `jsonBody` |
+| Delegate an open-ended goal to an environment | `do_action` `/businessapps/environments/{environmentId}/execute-work` with `{"instruction":"...","sessionId":"<optional>"}` |
+| Invoke an in-app MCP tool | `do_action` on the exact `/businessapps/environments/{environmentId}/mcp/{serverName}/tools/{toolName}` path |
 
 `call_function` supports an optional `jsonBody` for Business Applications paths. Continue encoding Microsoft
-Graph/OData function parameters in the URL; use `jsonBody` only when the discovered `/applications` function schema
+Graph/OData function parameters in the URL; use `jsonBody` only when the discovered `/businessapps` function schema
 requires it, especially the environment query and Custom API paths.
 
 Business Applications record file operations are distinct from Microsoft Graph binary content and the
 `fetch_blob` / `upload_blob` release status. Do not substitute those Graph blob tools for the
-`/applications/.../files/{columnName}/upload` or `/download` routes, and do not generalize these routes to OneDrive,
+`/businessapps/.../files/{columnName}/upload` or `/download` routes, and do not generalize these routes to OneDrive,
 SharePoint, mail attachments, or other Graph resources.
+
+## Business skills
+
+Business skills are reusable, environment-scoped capabilities that a business application exposes, and they are
+addressed like any other Business Applications resource. They are **not** the same thing as this WorkIQ skill or
+its `references/*.md` files.
+
+- Read one skill with `fetch` on `/businessapps/environments/{environmentId}/skills/{skillName}`, or list the
+  collection with `fetch` on `/businessapps/environments/{environmentId}/skills`.
+- Skills are writable with the same entity tools used for records: `create_entity` on the `skills` collection,
+  and `update_entity` or `delete_entity` on the concrete `skills/{skillName}` path.
+- Call `get_schema` on the skill or collection path before a create or update, and send only schema-confirmed
+  fields. Do not infer a skill's payload shape from a record or table payload.
+- Resolve `{skillName}` from discovery (`do_action` on `/businessapps/me` or `search_paths`) and preserve the
+  exact returned casing. Do not invent skill names.
 
 ## When to use `execute-work`
 
@@ -73,9 +93,9 @@ rather than claiming success.
 App-scoped paths intentionally differ from environment table paths:
 
 - Environment record collection:
-  `/applications/environments/{environmentId}/tables/{tableName}/records`
+  `/businessapps/environments/{environmentId}/tables/{tableName}/records`
 - App table:
-  `/applications/environments/{environmentId}/apps/{appName}/tables/{tableName}`
+  `/businessapps/environments/{environmentId}/apps/{appName}/tables/{tableName}`
 - App operations are directly under the app table or record path and **omit `/records/`**. Use only operation names
   returned by `get_schema`, such as `view`, `read`, `prepare_create`, `submit_create`, `prepare_update`,
   `submit_update`, `prepare_delete`, or `submit_delete`.
@@ -84,13 +104,13 @@ App-scoped paths intentionally differ from environment table paths:
 
 ## Grounding rules
 
-- WorkIQ's top-level `ask` can also answer questions about Business Applications request, though some applications may not be included in ask() so you may need to explore both ask() and /applications/me paths to get an answer.
-- Do not invent `/applications` REST shapes, append OData syntax to an undiscovered Business Applications path, or
+- WorkIQ's top-level `ask` can also answer questions about Business Applications request, though some applications may not be included in ask() so you may need to explore both ask() and /businessapps/me paths to get an answer.
+- Do not invent `/businessapps` REST shapes, append OData syntax to an undiscovered Business Applications path, or
   move `/records/` into an app-scoped path.
 - Preserve exact casing and IDs returned by tools in subsequent calls, although structural path segments are
   case-insensitive.
 - A write is complete only when the tool response confirms it. For a multi-turn delegated workflow, preserve and
   reuse the returned/provided `sessionId`; drafting and sending are separate turns when the workflow requires
   confirmation.
-- For metadata-only questions, prefer `search_paths` or `/applications/me`, then fetch the returned resource. For
+- For metadata-only questions, prefer `search_paths` or `/businessapps/me`, then fetch the returned resource. For
   exact data reads/writes, use the environment/table/app paths directly after discovery.

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -10,14 +10,15 @@ substitute a separate endpoint, another MCP server, or an invented REST URL.
    `{"query":"<business record, workflow, or app intent>","environmentId":"<optional>","limit":10}`. The `query`
    is required. Results include grounded paths plus environment and application IDs. For example, use
    `{"query":"qualify a lead"}` to discover the relevant sales application and operations.
-2. Use `search_paths` to discover Business Applications paths. Set `filter` to a plain leading-slash path such as
-   `/businessapps` for path-prefix matching, or to a regular expression over paths when a narrower pattern is
-   needed. The filter is **not a natural-language or semantic search**. Returned paths can be passed directly to
-   `fetch`, `get_schema`, or a write tool.
-3. Discover **every** Business Applications resource this way — environments, apps, tables, records, skills, APIs,
+2. Use `fetch` on `/businessapps/environments/` when the user explicitly asks to list environments or identify the
+   default environment. Do not guess an environment ID.
+3. Use `search_paths` with a natural-language description of the business task when broader semantic discovery is
+   useful. For Business Applications, the provider interprets `filter` semantically rather than as a path-prefix
+   regex. Returned paths can be passed directly to `fetch`, `get_schema`, or a write tool.
+4. Discover **every** Business Applications resource this way — environments, apps, tables, records, skills, APIs,
    and operations. Take each identifier from the returned paths. Do not guess an ID or name, and do not assume a
    default environment.
-4. Use `get_schema` on the returned concrete path before an unfamiliar mutation or operation. Never fill in
+5. Use `get_schema` on the returned concrete path before an unfamiliar mutation or operation. Never fill in
    `{environmentId}`, `{tableName}`, `{recordId}`, `{appName}`, `{apiName}`, `{skillName}`, or operation names
    from memory.
 
@@ -25,9 +26,10 @@ substitute a separate endpoint, another MCP server, or an invented REST URL.
 
 | Intent | WorkIQ tool and Business Applications path |
 |---|---|
+| List environments/default | `fetch` `/businessapps/environments/` |
 | List or describe tables | `fetch` or `get_schema` `/businessapps/environments/{environmentId}/tables[/<tableName>]` |
 | Read a record | `fetch` `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}` |
-| Query environment data | `call_function` `/businessapps/environments/{environmentId}/query` with `jsonBody: {"querytext":"SELECT ..."}` |
+| Query environment data | `do_action` `/businessapps/environments/{environmentId}/query` with `jsonBody: {"querytext":"SELECT ..."}` |
 | Create a table | `create_entity` on `/businessapps/environments/{environmentId}/tables` with `{tableName, columns, displayName?, description?}` |
 | Create a record | `create_entity` on `/businessapps/environments/{environmentId}/tables/{tableName}/records` with `{"item":{...}}` |
 | Update a record | `update_entity` on `/businessapps/environments/{environmentId}/tables/{tableName}/records/{recordId}` with changed fields |
@@ -40,13 +42,13 @@ substitute a separate endpoint, another MCP server, or an invented REST URL.
 | Update a business skill | `update_entity` on `/businessapps/environments/{environmentId}/skills/{skillName}` with changed fields |
 | Delete a business skill | `delete_entity` on `/businessapps/environments/{environmentId}/skills/{skillName}` |
 | Run an app-scoped operation | `do_action` on the exact `.../apps/{appName}/.../operations/{operationName}` path returned by `get_schema` |
-| Invoke a Custom API | `call_function` `/businessapps/environments/{environmentId}/apis/{apiName}` with the API inputs in `jsonBody` |
+| Invoke a Custom API | `do_action` on the exact `/businessapps/environments/{environmentId}/customapis/{apiName}` path returned by discovery, with API inputs in `jsonBody` |
 | Delegate an open-ended goal to an environment | `do_action` `/businessapps/environments/{environmentId}/execute-work` with `{"instruction":"...","sessionId":"<optional>"}` |
 | Invoke an in-app MCP tool | `do_action` on the exact `/businessapps/environments/{environmentId}/mcp/{serverName}/tools/{toolName}` path |
 
-`call_function` supports an optional `jsonBody` for Business Applications paths. Continue encoding Microsoft
-Graph/OData function parameters in the URL; use `jsonBody` only when the discovered `/businessapps` function schema
-requires it, especially the environment query and Custom API paths.
+Environment SQL queries and Custom APIs with input bodies are actions, not functions. Use `do_action` with the
+schema-defined `jsonBody`. Use `call_function` only for an exact function path returned by discovery; do not use it
+for `/businessapps/environments/{environmentId}/query`.
 
 Business Applications record file operations are distinct from Microsoft Graph binary content and the
 `fetch_blob` / `upload_blob` release status. Do not substitute those Graph blob tools for the
@@ -79,7 +81,8 @@ Prefer direct tools when WorkIQ already exposes the precise operation:
 
 - Use `fetch`, `get_schema`, or `search_paths` for discovery, metadata, and exact reads.
 - Use `create_entity`, `update_entity`, or `delete_entity` for a known data mutation.
-- Use `call_function` for a discovered query or function.
+- Use `do_action` for a discovered environment SQL query; use `call_function`
+  only for a discovered function path.
 - Use `do_action` on a discovered app-scoped operation or Custom API when that operation directly satisfies the
   request.
 
@@ -87,6 +90,19 @@ Choose `execute-work` when the requested outcome is best expressed as a delegate
 WorkIQ operation. For a continuation, pass the prior `sessionId`; otherwise omit it. Treat the returned work result
 as evidence from the environment, and surface any ambiguity, partial completion, requested confirmation, or failure
 rather than claiming success.
+
+`execute-work` is not a fallback for a missing named skill, app operation, or
+Custom API. When the user asks to run a specific named capability:
+
+1. discover the environment's available skills and operations;
+2. fetch the candidate definition when one is returned;
+3. require an exact capability match before invoking it;
+4. if it does not exist, state that clearly and abstain from execution.
+
+Do not silently substitute a similar skill, combine nearby records into an
+invented result, or reinterpret a different workflow as the requested
+capability. You may offer discovered alternatives, but run one only after the
+user chooses it.
 
 ## App-scoped operations
 
@@ -104,7 +120,7 @@ App-scoped paths intentionally differ from environment table paths:
 
 ## Grounding rules
 
-- WorkIQ's top-level `ask` can also answer questions about Business Applications request, though some applications may not be included in ask() so you may need to explore both ask() and /businessapps/me paths to get an answer.
+- WorkIQ's top-level `ask` can also answer questions about Business Applications requests, though some applications may not be included in `ask`, so use `/businessapps/me` or `search_paths` for authoritative path discovery.
 - Do not invent `/businessapps` REST shapes, append OData syntax to an undiscovered Business Applications path, or
   move `/records/` into an app-scoped path.
 - Preserve exact casing and IDs returned by tools in subsequent calls, although structural path segments are

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -1,0 +1,96 @@
+# Business Applications
+
+Use WorkIQ entity tools with paths under `/applications/` for business-application environments, data, apps,
+skills, APIs, and operations. This path space is distinct from Microsoft Graph application registrations. Do not
+substitute a separate endpoint, another MCP server, or an invented REST URL.
+
+## Discovery and path grounding
+
+1. Start intent-driven discovery with `do_action` on `/applications/me` and
+   `{"query":"<business record, workflow, or app intent>","environmentId":"<optional>","limit":10}`. The `query`
+   is required. Results include grounded paths plus environment and application IDs. For example, use
+   `{"query":"qualify a lead"}` to discover the relevant sales application and operations.
+2. Use `fetch` on `/applications/environments/` when the user explicitly asks to list environments or identify the
+   default environment. Do not guess an environment ID.
+3. Use `search_paths` to discover Business Applications paths. Set `filter` to a plain leading-slash path such as
+   `/applications` for path-prefix matching, or to a regular expression over paths when a narrower pattern is
+   needed. The filter is **not a natural-language or semantic search**. Returned paths can be passed directly to
+   `fetch`, `get_schema`, or a write tool.
+4. Use `get_schema` on the returned concrete path before an unfamiliar mutation or operation. Never fill in
+   `{environmentId}`, `{tableName}`, `{recordId}`, `{appName}`, `{apiName}`, or operation names from memory.
+
+## Exact path and tool selection
+
+| Intent | WorkIQ tool and Business Applications path |
+|---|---|
+| List environments/default | `fetch` `/applications/environments/` |
+| List or describe tables | `fetch` or `get_schema` `/applications/environments/{environmentId}/tables[/<tableName>]` |
+| Read a record | `fetch` `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}` |
+| Query environment data | `call_function` `/applications/environments/{environmentId}/query` with `jsonBody: {"querytext":"SELECT ..."}` |
+| Create a table | `create_entity` on `/applications/environments/{environmentId}/tables` with `{tableName, columns, displayName?, description?}` |
+| Create a record | `create_entity` on `/applications/environments/{environmentId}/tables/{tableName}/records` with `{"item":{...}}` |
+| Update a record | `update_entity` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}` with changed fields |
+| Delete a record/table | `delete_entity` on the exact record or table path returned by discovery |
+| Upload a Business Applications record file | `do_action` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/upload` with the schema-defined file arguments |
+| Download a Business Applications record file | `call_function` on `/applications/environments/{environmentId}/tables/{tableName}/records/{recordId}/files/{columnName}/download` with optional `destinationPath` |
+| List or inspect apps | `fetch` `/applications/environments/{environmentId}/apps[/<appName>]` |
+| Run an app-scoped operation | `do_action` on the exact `.../apps/{appName}/.../operations/{operationName}` path returned by `get_schema` |
+| Invoke a Custom API | `call_function` `/applications/environments/{environmentId}/apis/{apiName}` with the API inputs in `jsonBody` |
+| Delegate an open-ended goal to an environment | `do_action` `/applications/environments/{environmentId}/execute-work` with `{"instruction":"...","sessionId":"<optional>"}` |
+| Invoke an in-app MCP tool | `do_action` on the exact `/applications/environments/{environmentId}/mcp/{serverName}/tools/{toolName}` path |
+
+`call_function` supports an optional `jsonBody` for Business Applications paths. Continue encoding Microsoft
+Graph/OData function parameters in the URL; use `jsonBody` only when the discovered `/applications` function schema
+requires it, especially the environment query and Custom API paths.
+
+Business Applications record file operations are distinct from Microsoft Graph binary content and the
+`fetch_blob` / `upload_blob` release status. Do not substitute those Graph blob tools for the
+`/applications/.../files/{columnName}/upload` or `/download` routes, and do not generalize these routes to OneDrive,
+SharePoint, mail attachments, or other Graph resources.
+
+## When to use `execute-work`
+
+Use `execute-work` when the user wants to **delegate an open-ended goal** to the business agent in a specific
+environment and completing that goal requires the environment to plan or coordinate multiple steps, choose among
+its skills or operations, or maintain a delegated work session. Discover the environment and confirm that its
+returned paths expose `execute-work`, then pass the user's complete goal in `instruction`.
+
+Prefer direct tools when WorkIQ already exposes the precise operation:
+
+- Use `fetch`, `get_schema`, or `search_paths` for discovery, metadata, and exact reads.
+- Use `create_entity`, `update_entity`, or `delete_entity` for a known data mutation.
+- Use `call_function` for a discovered query or function.
+- Use `do_action` on a discovered app-scoped operation or Custom API when that operation directly satisfies the
+  request.
+
+Choose `execute-work` when the requested outcome is best expressed as a delegated goal rather than a specific
+WorkIQ operation. For a continuation, pass the prior `sessionId`; otherwise omit it. Treat the returned work result
+as evidence from the environment, and surface any ambiguity, partial completion, requested confirmation, or failure
+rather than claiming success.
+
+## App-scoped operations
+
+App-scoped paths intentionally differ from environment table paths:
+
+- Environment record collection:
+  `/applications/environments/{environmentId}/tables/{tableName}/records`
+- App table:
+  `/applications/environments/{environmentId}/apps/{appName}/tables/{tableName}`
+- App operations are directly under the app table or record path and **omit `/records/`**. Use only operation names
+  returned by `get_schema`, such as `view`, `read`, `prepare_create`, `submit_create`, `prepare_update`,
+  `submit_update`, `prepare_delete`, or `submit_delete`.
+- Use `view` for bounded/form-aware app record browsing. Use `prepare_*` then `submit_*` when the schema exposes
+  that two-step operation.
+
+## Grounding rules
+
+- WorkIQ's top-level `ask` can also answer questions about Business Applications request, though some applications may not be included in ask() so you may need to explore both ask() and /applications/me paths to get an answer.
+- Do not invent `/applications` REST shapes, append OData syntax to an undiscovered Business Applications path, or
+  move `/records/` into an app-scoped path.
+- Preserve exact casing and IDs returned by tools in subsequent calls, although structural path segments are
+  case-insensitive.
+- A write is complete only when the tool response confirms it. For a multi-turn delegated workflow, preserve and
+  reuse the returned/provided `sessionId`; drafting and sending are separate turns when the workflow requires
+  confirmation.
+- For metadata-only questions, prefer `search_paths` or `/applications/me`, then fetch the returned resource. For
+  exact data reads/writes, use the environment/table/app paths directly after discovery.

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -70,6 +70,26 @@ its `references/*.md` files.
 - Resolve `{skillName}` from discovery (`do_action` on `/businessapps/me` or `search_paths`) and preserve the
   exact returned casing. Do not invent skill names.
 
+## Approval and privilege boundaries
+
+Business Applications writes execute immediately. Apply the general WorkIQ
+write-confirmation rule before calling `create_entity`, `update_entity`,
+`delete_entity`, or a mutating `do_action`.
+
+- If the user explicitly says a preview or deletion is **not approved**, use
+  discovery and reads only. Do not call the write tool merely to let the
+  server reject it, and do not treat a rejection as a substitute for user
+  confirmation.
+- When prior transcript context records an explicit approval, perform only the
+  approved mutation, once, through the schema-defined path.
+- If the approved operation fails for a missing privilege, authorization, or
+  policy, **stop the mutation workflow immediately** and report that exact
+  failure. Do not continue searching for another write route. Do not modify a
+  different table, record, view, saved query, skill, or app artifact as a
+  workaround and do not claim the requested operation succeeded.
+- Schema and customization requests must use the discovered schema-mutation
+  operation. Record-level access does not imply customization rights.
+
 ## When to use `execute-work`
 
 Use `execute-work` when the user wants to **delegate an open-ended goal** to the business agent in a specific

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -90,27 +90,6 @@ write-confirmation rule before calling `create_entity`, `update_entity`,
 - Schema and customization requests must use the discovered schema-mutation
   operation. Record-level access does not imply customization rights.
 
-## Exact scope and governed terminology
-
-Do not silently broaden or reinterpret an explicit business scope.
-
-- When the user names an environment, app, skill, view, measure, tier, status,
-  or other governed concept, require an exact accessible match before reading
-  records or acting.
-- If no accessible environment matches the requested name, say only that no
-  accessible matching environment was found and stop after that scoped
-  discovery result. Do not list other environments, call broad `fetch` or
-  `search_paths`, confirm whether a hidden environment exists, inspect the same
-  record elsewhere, expose alternate records, or redirect the write.
-- If a governed glossary has no definition for the requested term, do not map
-  it to a name-similar field, category, threshold, or inferred business rule.
-  When discovery returns the glossary resource, fetch that glossary once to
-  ground the absence and any defined alternatives. Then state that the term is
-  undefined and ask what criteria should qualify, or offer only alternatives
-  that the fetched glossary actually defines.
-- Once exact-scope discovery proves the requested scope or concept unavailable,
-  stop exploratory record queries unless the user chooses an alternative.
-
 ## When to use `execute-work`
 
 Use `execute-work` when the user wants to **delegate an open-ended goal** to the business agent in a specific

--- a/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/business-applications.md
@@ -90,6 +90,27 @@ write-confirmation rule before calling `create_entity`, `update_entity`,
 - Schema and customization requests must use the discovered schema-mutation
   operation. Record-level access does not imply customization rights.
 
+## Exact scope and governed terminology
+
+Do not silently broaden or reinterpret an explicit business scope.
+
+- When the user names an environment, app, skill, view, measure, tier, status,
+  or other governed concept, require an exact accessible match before reading
+  records or acting.
+- If no accessible environment matches the requested name, say only that no
+  accessible matching environment was found and stop after that scoped
+  discovery result. Do not list other environments, call broad `fetch` or
+  `search_paths`, confirm whether a hidden environment exists, inspect the same
+  record elsewhere, expose alternate records, or redirect the write.
+- If a governed glossary has no definition for the requested term, do not map
+  it to a name-similar field, category, threshold, or inferred business rule.
+  When discovery returns the glossary resource, fetch that glossary once to
+  ground the absence and any defined alternatives. Then state that the term is
+  undefined and ask what criteria should qualify, or offer only alternatives
+  that the fetched glossary actually defines.
+- Once exact-scope discovery proves the requested scope or concept unavailable,
+  stop exploratory record queries unless the user chooses an alternative.
+
 ## When to use `execute-work`
 
 Use `execute-work` when the user wants to **delegate an open-ended goal** to the business agent in a specific


### PR DESCRIPTION
Adds guidance for the Business Applications (`/businessapps`) path space to the `workiq-preview` skill.

### Changes
- **`SKILL.md`** (+26) — routing-table entries for structured records/workflows in CRM, ERP, and Power Apps; `/businessapps/me` in the entity-tools table; new "Business Applications" section; authorization-failure guidance for writes.
- **`references/business-applications.md`** (new, 152 lines) — discovery and path-grounding rules, tool/path selection table, business skills, approval and privilege boundaries, `execute-work` guidance, and app-scoped operation conventions.

### Notes
- Documentation only — no code or configuration changes.
- Ported from `thejeffand/work-iq` branch `user/jeffand/bizapps` (tip `bae1211`) via cherry-pick, so original authorship is preserved.
- Content is byte-identical to the source branch for both files.